### PR TITLE
Handle errors when syncing entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-backend-plugin",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/service/task.ts
+++ b/src/service/task.ts
@@ -41,7 +41,7 @@ export const syncEntities: (options: SyncEntitiesOptions) => void = async ({ log
   logger.info("Syncing entities with Cortex...")
   try {
     await cortexApi.syncEntities(entities, customMappings, { token })
-  } catch (err) {
+  } catch (err: any) {
     logger.error(`Error while syncing entties with Cortex: ${err.message}`)
   }
   

--- a/src/service/task.ts
+++ b/src/service/task.ts
@@ -39,6 +39,11 @@ export const syncEntities: (options: SyncEntitiesOptions) => void = async ({ log
   const { items: entities } = await catalogApi.getEntities(undefined, { token })
 
   logger.info("Syncing entities with Cortex...")
-  await cortexApi.syncEntities(entities, customMappings, { token })
+  try {
+    await cortexApi.syncEntities(entities, customMappings, { token })
+  } catch (err) {
+    logger.error(`Error while syncing entties with Cortex: ${err.message}`)
+  }
+  
   logger.info("Finished syncing entities with Cortex")
 }


### PR DESCRIPTION
Currently when attempting to sync entities, if there is an error
while communicating with the Cortex API we throw an error and do not
catch it. Leading to crashing the main backstage backend process and
potential downtime

This wraps the sync entities call in a try/catch and logs the issue
instead