### PR TITLE
[CET-4196] Optional filter to limit entities sent to Cortex

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@backstage/config": "^1.0.7",
     "@backstage/config-loader": "^1.1.9",
     "@backstage/errors": "^1.1.5",
-    "@cortexapps/backstage-plugin-extensions": "0.0.12",
+    "@cortexapps/backstage-plugin-extensions": "0.0.19",
     "@types/express": "^4.17.6",
     "@types/node-cron": "^2.0.4",
     "cross-fetch": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-backend-plugin",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 import { Entity } from '@backstage/catalog-model';
-import { CustomMapping, TeamOverrides } from "@cortexapps/backstage-plugin-extensions";
+import { TeamOverrides } from "@cortexapps/backstage-plugin-extensions";
 import { EntitySyncProgress, RequestOptions } from "./types";
 
 export interface CortexApi {
   submitEntitySync(
     entities: Entity[],
     shouldGzipBody: boolean,
-    customMappings?: CustomMapping[],
     teamOverrides?: TeamOverrides,
     requestOptions?: RequestOptions,
   ): Promise<EntitySyncProgress>;

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -39,21 +39,16 @@ export class CortexClient implements CortexApi {
   async submitEntitySync(
     entities: Entity[],
     shouldGzipBody: boolean,
-    customMappings?: CustomMapping[],
     teamOverrides?: TeamOverrides,
     requestOptions?: RequestOptions
   ): Promise<EntitySyncProgress> {
-    const withCustomMappings: Entity[] = customMappings
-      ? entities.map(entity => applyCustomMappings(entity, customMappings))
-      : entities;
-
     const post = async (path: string, body?: any) => {
       return shouldGzipBody ? await this.postVoidWithGzipBody(path, body, requestOptions) : await this.postVoid(path, body, requestOptions)
     }
 
     await this.postVoid('/api/backstage/v2/entities/sync-init', requestOptions)
 
-    for (let customMappingsChunk of chunk(withCustomMappings, CHUNK_SIZE)) {
+    for (let customMappingsChunk of chunk(entities, CHUNK_SIZE)) {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: customMappingsChunk,
       })

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -16,8 +16,7 @@
 import { CortexApi } from "./CortexApi";
 import { Entity } from '@backstage/catalog-model';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
-import { CustomMapping, TeamOverrides } from "@cortexapps/backstage-plugin-extensions";
-import { applyCustomMappings } from "../utils/componentUtils";
+import { TeamOverrides } from "@cortexapps/backstage-plugin-extensions";
 import { EntitySyncProgress, RequestOptions } from "./types";
 import { Buffer } from "buffer";
 import { gzipSync } from "zlib";

--- a/src/service/task.test.ts
+++ b/src/service/task.test.ts
@@ -143,9 +143,10 @@ describe('task', () => {
         }
 
         const catalogApi: Partial<CatalogApi> = {
-            async getEntities({ filter }) {
-                console.log(filter);
-                if (filter['kind'] === undefined) {
+            async getEntities(request) {
+                let filter = request?.filter as Record<string, string[]> | undefined
+                let kindFilter: string[] | undefined = filter?.['kind']
+                if (kindFilter === undefined) {
                     throw Error('Kind filter extension not in use')
                 }
                 return {

--- a/src/service/task.test.ts
+++ b/src/service/task.test.ts
@@ -20,7 +20,6 @@ import { ExtensionApi } from "@cortexapps/backstage-plugin-extensions";
 import { CatalogApi } from "@backstage/catalog-client";
 import { submitEntitySync } from "./task";
 import * as winston from "winston";
-import { captor } from "jest-mock-extended";
 
 describe('task', () => {
     const logger = winston.createLogger({

--- a/src/service/task.ts
+++ b/src/service/task.ts
@@ -30,7 +30,7 @@ interface SyncEntitiesOptions {
   tokenManager?: TokenManager;
 }
 
-const getBackstageEntities: (options: { catalogApi: CatalogApi, extensionApi: ExtensionApi }) => Promise<Entity[]> = async ({
+const getBackstageEntities: (options: { catalogApi: CatalogApi, extensionApi?: ExtensionApi }) => Promise<Entity[]> = async ({
   catalogApi,
   extensionApi,
 }) => {

--- a/src/service/task.ts
+++ b/src/service/task.ts
@@ -18,6 +18,8 @@ import { Logger } from 'winston';
 import { CatalogApi } from "@backstage/catalog-client";
 import { ExtensionApi } from "@cortexapps/backstage-plugin-extensions";
 import { TokenManager } from "@backstage/backend-common";
+import { Entity } from "@backstage/catalog-model";
+import { applyCustomMappings } from "../utils/componentUtils";
 
 interface SyncEntitiesOptions {
   logger: Logger;
@@ -28,7 +30,30 @@ interface SyncEntitiesOptions {
   tokenManager?: TokenManager;
 }
 
-export const submitEntitySync: (options: SyncEntitiesOptions) => void = async ({ logger, cortexApi, syncWithGzip, catalogApi, extensionApi, tokenManager }) => {
+const getBackstageEntities: (options: { catalogApi: CatalogApi, extensionApi: ExtensionApi }) => Promise<Entity[]> = async ({
+  catalogApi,
+  extensionApi,
+}) => {
+  const syncEntityFilter = await extensionApi?.getSyncEntityFilter?.();
+  const { items: entities } = await catalogApi.getEntities(
+    syncEntityFilter?.kinds
+      ? { filter: { kind: syncEntityFilter?.kinds } }
+      : undefined,
+  );
+  const filteredEntities = syncEntityFilter?.entityFilter
+    ? entities.filter(syncEntityFilter?.entityFilter)
+    : entities;
+
+  const customMappings = await extensionApi?.getCustomMappings?.();
+  const withCustomMappings: Entity[] = customMappings
+    ? filteredEntities.map(entity =>
+      applyCustomMappings(entity, customMappings),
+    )
+    : filteredEntities;
+
+  return withCustomMappings;
+}
+export const submitEntitySync: (options: SyncEntitiesOptions) => Promise<void> = async ({ logger, cortexApi, syncWithGzip, catalogApi, extensionApi, tokenManager }) => {
   let token: string | undefined = undefined;
   if (tokenManager !== undefined) {
     logger.info("Using TokenManager for catalog request");
@@ -36,15 +61,14 @@ export const submitEntitySync: (options: SyncEntitiesOptions) => void = async ({
   }
 
   logger.info("Fetching all Backstage entities...")
-  const { items: entities } = await catalogApi.getEntities(undefined, { token })
+  const entities = await getBackstageEntities({ catalogApi, extensionApi })
 
   logger.info("Fetching Cortex extensions...")
-  const customMappings = await extensionApi?.getCustomMappings?.()
   const groupOverrides = await extensionApi?.getTeamOverrides?.(entities);
 
   logger.info("Submitting entity sync task to Cortex...")
   try {
-    await cortexApi.submitEntitySync(entities, syncWithGzip, customMappings, groupOverrides, { token })
+    await cortexApi.submitEntitySync(entities, syncWithGzip, groupOverrides, { token })
   } catch (err: any) {
     logger.error(`Error while submitting entity sync task to Cortex: ${err.message}`)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,7 +2237,7 @@
     "@backstage/errors" "^1.1.5"
     cross-fetch "^3.1.5"
 
-"@backstage/catalog-model@^1.0.0", "@backstage/catalog-model@^1.2.1":
+"@backstage/catalog-model@^1.2.1":
   version "1.2.1"
   resolved "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.2.1.tgz#ee3fa9ec404cef4a6b639160c7c016fbdd53229f"
   integrity sha512-pbH67Nov/bgJYIOl78ncjUfCPbjAI+VScfGRhGmcFubqK+w9pygy6Y/sYg10u5NFJxKCoSnbYZehO0451UbqhA==
@@ -2506,12 +2506,12 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cortexapps/backstage-plugin-extensions@0.0.12":
-  version "0.0.12"
-  resolved "https://registry.npmjs.org/@cortexapps/backstage-plugin-extensions/-/backstage-plugin-extensions-0.0.12.tgz#9317cf45ac41738524f6b2301b549f662d29f968"
-  integrity sha512-zdpEKgmDNKxTSquURFiBXmjloKNQ6uJIolqspuG6BH8KQaeeMQYdYusjYcZbjegn+ahygPKT11SFq8sXn7LUhA==
+"@cortexapps/backstage-plugin-extensions@0.0.19":
+  version "0.0.19"
+  resolved "https://registry.npmjs.org/@cortexapps/backstage-plugin-extensions/-/backstage-plugin-extensions-0.0.19.tgz#ef0f5a4e99fe12b3c432ecd1e0b1a2158947e113"
+  integrity sha512-lZfK94+UxfWzUwhgGlgWn9anjk2GNrYVvYrkih8Axr4n/AuaNYejgRsQqNpayOt+KBX08D1KEQvOsWIExjvL/g==
   dependencies:
-    "@backstage/catalog-model" "^1.0.0"
+    "@backstage/catalog-model" "^1.2.1"
 
 "@cortexapps/eslint-config-oss@^0.0.3":
   version "0.0.3"


### PR DESCRIPTION
## Change description
Give users the option to limit which entities are sent over to Cortex for the YAML conversion / sync -- we're sending way too much data for larger instances of Backstage, and this will give some configuration power back to the users if there's completely unused data being sent to Cortex.