### PR TITLE
clarified what the ${CORTEX_BACKEND_HOST_URL} should be

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ apiRouter.use('/cortex', await cortex(cortexEnv));
       Authorization: Bearer ${CORTEX_TOKEN}
 ```
 > ℹ️ 
-> The ${CORTEX_BACKEND_HOST_URL} value should point to the Cortex API. If syncing to Cortex Cloud this would be `https://api.getcortexapp.com`. If running Cortex Self-Managed, please updated accordingly.
+> The ${CORTEX_BACKEND_HOST_URL} value should point to the Cortex API. If syncing to Cortex cloud this would be `https://api.getcortexapp.com`. If running Cortex self-managed, please update accordingly.
 
 5. (Optional) You can choose to have the entity sync cron job use gzip to compress the entities by updating `cortex.ts` from step 2. You must also update the Backstage HTTP proxy to allow the `Content-Encoding` header.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ apiRouter.use('/cortex', await cortex(cortexEnv));
     headers:
       Authorization: Bearer ${CORTEX_TOKEN}
 ```
+> ℹ️ 
+> The ${CORTEX_BACKEND_HOST_URL} value should point to the Cortex API. If syncing to Cortex Cloud this would be `https://api.getcortexapp.com`. If running Cortex Self-Managed, please updated accordingly.
 
 5. (Optional) You can choose to have the entity sync cron job use gzip to compress the entities by updating `cortex.ts` from step 2. You must also update the Backstage HTTP proxy to allow the `Content-Encoding` header.
 


### PR DESCRIPTION
Documentation was not straight forward implying that this value should be https://app.getcortexapp.com/ rather than the api endpoint