### PR TITLE
Added missing backstage.pluginId.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
+    "pluginId": "@cortexapps/backstage-backend-plugin",
     "role": "backend-plugin"
   },
   "scripts": {


### PR DESCRIPTION
After updating `@backstage-cli` to newer version, additional check if made before publishing plugin and we are missing `backstage.pluginId` in our packstage.json.

In this PR I've set this field to `@cortexapps/backstage-backend-plugin`