### PR TITLE
Added missing backstage.pluginPackages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   },
   "backstage": {
     "pluginId": "@cortexapps/backstage-backend-plugin",
+    "pluginPackages": [
+      "@cortexapps/backstage-backend-plugin"
+    ],
     "role": "backend-plugin"
   },
   "scripts": {


### PR DESCRIPTION
After updating @backstage-cli to newer version, additional check if made before publishing plugin and we are missing backstage.pluginPackages in our package.json.