### PR TITLE
CET-12215 Update plugin-to-plugin auth to use auth token generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-backend-plugin",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -52,10 +52,12 @@ export async function createRouter(
     response.send({ status: 'ok' });
   });
   
-  const { auth } = createLegacyAuthAdapters(options)
+  const { auth } = createLegacyAuthAdapters(options);
+  const cronSchedule = '* * * * *';
 
   await initCron({
     ...options,
+    cronSchedule,
     auth,
   });
 

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 import {
-  PluginEndpointDiscovery,
   TokenManager,
+  createLegacyAuthAdapters,
 } from '@backstage/backend-common';
+import {
+  AuthService,
+  DiscoveryService,
+  HttpAuthService,
+} from '@backstage/backend-plugin-api'
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
@@ -28,11 +33,13 @@ import { CatalogClient } from '@backstage/catalog-client';
 
 export interface RouterOptions {
   logger: Logger;
-  discoveryApi: PluginEndpointDiscovery;
+  discovery: DiscoveryService;
   cronSchedule: string;
   syncWithGzip?: boolean;
   extensionApi?: ExtensionApi;
   tokenManager?: TokenManager;
+  auth?: AuthService;
+  httpAuth?: HttpAuthService;
 }
 
 export async function createRouter(
@@ -44,24 +51,38 @@ export async function createRouter(
   router.get('/health', (_, response) => {
     response.send({ status: 'ok' });
   });
+  
+  const { auth } = createLegacyAuthAdapters(options)
 
-  await initCron(options);
+  await initCron({
+    ...options,
+    auth,
+  });
 
   return router;
 }
 
-async function initCron(options: RouterOptions) {
+export interface CronOptions {
+  logger: Logger;
+  discovery: DiscoveryService;
+  cronSchedule: string;
+  syncWithGzip?: boolean;
+  extensionApi?: ExtensionApi;
+  auth: AuthService;
+}
+
+async function initCron(options: CronOptions) {
   const {
     logger,
-    discoveryApi,
+    discovery,
     syncWithGzip,
     cronSchedule,
     extensionApi,
-    tokenManager,
+    auth,
   } = options;
 
-  const catalogApi = new CatalogClient({ discoveryApi });
-  const cortexApi = new CortexClient({ discoveryApi });
+  const catalogApi = new CatalogClient({ discoveryApi: discovery });
+  const cortexApi = new CortexClient({ discoveryApi: discovery });
 
   cron.schedule(cronSchedule, () => {
     submitEntitySync({
@@ -70,7 +91,7 @@ async function initCron(options: RouterOptions) {
       cortexApi,
       syncWithGzip: syncWithGzip ?? false,
       extensionApi,
-      tokenManager,
+      auth,
     });
   });
 }

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -53,11 +53,9 @@ export async function createRouter(
   });
   
   const { auth } = createLegacyAuthAdapters(options);
-  const cronSchedule = '* * * * *';
 
   await initCron({
     ...options,
-    cronSchedule,
     auth,
   });
 

--- a/src/service/standaloneServer.ts
+++ b/src/service/standaloneServer.ts
@@ -18,9 +18,6 @@ import {
   loadBackendConfig,
   HostDiscovery,
 } from '@backstage/backend-common';
-import {
-  AuthService
-} from '@backstage/backend-plugin-api';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { createRouter } from './router';

--- a/src/service/standaloneServer.ts
+++ b/src/service/standaloneServer.ts
@@ -16,7 +16,7 @@
 import {
   createServiceBuilder,
   loadBackendConfig,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';
@@ -34,7 +34,7 @@ export async function startStandaloneServer(
   const logger = options.logger.child({ service: 'cortex-backend' });
 
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discoveryApi = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const cronSchedule =
     config.getOptionalString('cortex.backend.cron') ??
     '0 3,7,11,15,19,23 * * *';
@@ -44,7 +44,7 @@ export async function startStandaloneServer(
   logger.debug('Starting application server...');
   const router = await createRouter({
     logger,
-    discoveryApi,
+    discovery,
     cronSchedule,
     syncWithGzip,
   });

--- a/src/service/standaloneServer.ts
+++ b/src/service/standaloneServer.ts
@@ -18,6 +18,9 @@ import {
   loadBackendConfig,
   HostDiscovery,
 } from '@backstage/backend-common';
+import {
+  AuthService
+} from '@backstage/backend-plugin-api';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { createRouter } from './router';

--- a/src/service/task.test.ts
+++ b/src/service/task.test.ts
@@ -15,6 +15,7 @@
  */
 import { CortexApi } from '../api/CortexApi';
 import mock from 'jest-mock-extended/lib/Mock';
+import { AuthService } from '@backstage/backend-plugin-api'
 import { Entity } from '@backstage/catalog-model';
 import { ExtensionApi } from '@cortexapps/backstage-plugin-extensions';
 import { CatalogApi } from '@backstage/catalog-client';
@@ -26,6 +27,8 @@ describe('task', () => {
     transports: [new winston.transports.Console()],
   });
   const cortexApi = mock<CortexApi>();
+  const auth = mock<AuthService>();
+  auth.getPluginRequestToken.mockResolvedValue({ token: "token" })
 
   const component1: Entity = {
     apiVersion: '1',
@@ -105,13 +108,14 @@ describe('task', () => {
       syncWithGzip: false,
       catalogApi: catalogApi as CatalogApi,
       extensionApi,
+      auth,
     });
 
     expect(cortexApi.submitEntitySync).toHaveBeenLastCalledWith(
       [{ ...component1, spec: extension }],
       false,
       { teams, relationships },
-      { token: undefined },
+      { token: "token" },
     );
   });
 
@@ -122,13 +126,14 @@ describe('task', () => {
       syncWithGzip: true,
       catalogApi: catalogApi as CatalogApi,
       extensionApi,
+      auth,
     });
 
     expect(cortexApi.submitEntitySync).toHaveBeenLastCalledWith(
       [{ ...component1, spec: extension }],
       true,
       { teams, relationships },
-      { token: undefined },
+      { token: "token" },
     );
   });
 
@@ -160,13 +165,14 @@ describe('task', () => {
       syncWithGzip: true,
       catalogApi: catalogApi as CatalogApi,
       extensionApi,
+      auth,
     });
 
     expect(cortexApi.submitEntitySync).toHaveBeenLastCalledWith(
       [component1],
       true,
       undefined,
-      { token: undefined },
+      { token: "token" },
     );
   });
 
@@ -194,13 +200,14 @@ describe('task', () => {
       syncWithGzip: true,
       catalogApi: catalogApi as CatalogApi,
       extensionApi,
+      auth,
     });
 
     expect(cortexApi.submitEntitySync).toHaveBeenLastCalledWith(
       [component1],
       true,
       undefined,
-      { token: undefined },
+      { token: "token" },
     );
   });
 });


### PR DESCRIPTION
After clients upgrade their Backstage backend, our plugin's requests to the catalog plugin are now throwing 401s. Backstage is forcing a new non-static token auth method which requires requesting a JWT for cross-plugin calls.
This PR implements the migration process for plugin-to-plugin auth described here https://backstage.io/docs/tutorials/auth-service-migration/