### PR TITLE
Use createBackendPlugin to export plugin ref in new backend pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-backend-plugin",
-  "version": "1.6.4",
+  "version": "1.6.4-a",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "@backstage/config": "^1.2.0",
     "@backstage/config-loader": "^1.8.0",
     "@backstage/errors": "^1.2.4",
-    "@cortexapps/backstage-plugin-extensions": "0.0.22",
+    "@cortexapps/backstage-plugin-extensions": "0.0.24",
     "@types/express": "^4.17.6",
     "@types/node-cron": "^2.0.4",
     "cross-fetch": "^3.0.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,37 +19,50 @@ import {
     createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
+import { cortexExtensionApiExtensionPoint, ExtensionApi } from '@cortexapps/backstage-plugin-extensions';
 
 export const cortexPlugin = createBackendPlugin({
     pluginId: 'cortex',
+    
     register(env) {
-        env.registerInit({
-        deps: {
-            logger: coreServices.logger,
-            config: coreServices.rootConfig,
-            discovery: coreServices.discovery,
-            // The http router service is used to register the router created by the createRouter.
-            http: coreServices.httpRouter,
-            auth: coreServices.auth,
-            httpAuth: coreServices.httpAuth
-        },
-        async init({ config, logger, discovery, http, auth, httpAuth }) {
-            const cronSchedule =
-                config.getOptionalString('cortex.backend.cron') ?? '0 3,7,11,15,19,23 * * *';
-            const syncWithGzip =
-                config.getOptionalBoolean('cortex.syncWithGzip') ?? false;
-            const router = await createRouter({
-                logger,
-                discovery,
-                cronSchedule,
-                syncWithGzip,
-                auth,
-                httpAuth,
-            });
+        let cortexExtensionApi: ExtensionApi | undefined = undefined;
+        env.registerExtensionPoint(cortexExtensionApiExtensionPoint, {
+            setExtensionApi(extensionApi) {
+                if (extensionApi) {
+                    throw new Error('ExtensionApi may only be set once')
+                }
+                cortexExtensionApi = extensionApi
+            }
+        });
 
-            // We register the router with the http service.
-            http.use(router);
-        },
+        env.registerInit({
+            deps: {
+                logger: coreServices.logger,
+                config: coreServices.rootConfig,
+                discovery: coreServices.discovery,
+                // The http router service is used to register the router created by the createRouter.
+                http: coreServices.httpRouter,
+                auth: coreServices.auth,
+                httpAuth: coreServices.httpAuth
+            },
+            async init({ config, logger, discovery, http, auth, httpAuth }) {
+                const cronSchedule =
+                    config.getOptionalString('cortex.backend.cron') ?? '0 3,7,11,15,19,23 * * *';
+                const syncWithGzip =
+                    config.getOptionalBoolean('cortex.syncWithGzip') ?? false;
+                const router = await createRouter({
+                    logger,
+                    discovery,
+                    cronSchedule,
+                    syncWithGzip,
+                    extensionApi: cortexExtensionApi,
+                    auth,
+                    httpAuth,
+                });
+
+                // We register the router with the http service.
+                http.use(router);
+            },
         });
     },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import {
     coreServices,
     createBackendPlugin,
 } from '@backstage/backend-plugin-api';
-import {  } from '@cortexapps/backstage-plugin-extensions';
 import { createRouter } from './service/router';
 
 export const cortexPlugin = createBackendPlugin({

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import {
+    coreServices,
+    createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import {  } from '@cortexapps/backstage-plugin-extensions';
+import { createRouter } from './service/router';
+
+export const cortexPlugin = createBackendPlugin({
+    pluginId: 'cortex',
+    register(env) {
+        env.registerInit({
+        deps: {
+            logger: coreServices.logger,
+            config: coreServices.rootConfig,
+            discovery: coreServices.discovery,
+            // The http router service is used to register the router created by the createRouter.
+            http: coreServices.httpRouter,
+            auth: coreServices.auth,
+            httpAuth: coreServices.httpAuth
+        },
+        async init({ config, logger, discovery, http, auth, httpAuth }) {
+            const cronSchedule =
+                config.getOptionalString('cortex.backend.cron') ?? '0 3,7,11,15,19,23 * * *';
+            const syncWithGzip =
+                config.getOptionalBoolean('cortex.syncWithGzip') ?? false;
+            const router = await createRouter({
+                logger,
+                discovery,
+                cronSchedule,
+                syncWithGzip,
+                auth,
+                httpAuth,
+            });
+
+            // We register the router with the http service.
+            http.use(router);
+        },
+        });
+    },
+});
+
 export * from './service/router';

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -21,10 +21,10 @@ import {
   AuthService,
   DiscoveryService,
   HttpAuthService,
+  LoggerService,
 } from '@backstage/backend-plugin-api'
 import express from 'express';
 import Router from 'express-promise-router';
-import { Logger } from 'winston';
 import * as cron from 'node-cron';
 import { CortexClient } from '../api/CortexClient';
 import { submitEntitySync } from './task';
@@ -32,7 +32,7 @@ import { ExtensionApi } from '@cortexapps/backstage-plugin-extensions';
 import { CatalogClient } from '@backstage/catalog-client';
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: LoggerService;
   discovery: DiscoveryService;
   cronSchedule: string;
   syncWithGzip?: boolean;
@@ -63,7 +63,7 @@ export async function createRouter(
 }
 
 export interface CronOptions {
-  logger: Logger;
+  logger: LoggerService;
   discovery: DiscoveryService;
   cronSchedule: string;
   syncWithGzip?: boolean;

--- a/src/service/task.ts
+++ b/src/service/task.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 import { CortexApi } from '../api/CortexApi';
-import { Logger } from 'winston';
 import { CatalogApi } from '@backstage/catalog-client';
 import { ExtensionApi } from '@cortexapps/backstage-plugin-extensions';
-import { AuthService } from '@backstage/backend-plugin-api'
+import { AuthService, LoggerService } from '@backstage/backend-plugin-api'
 import { Entity } from '@backstage/catalog-model';
 import { applyCustomMappings } from '../utils/componentUtils';
 
 interface SyncEntitiesOptions {
-  logger: Logger;
+  logger: LoggerService;
   cortexApi: CortexApi;
   syncWithGzip: boolean;
   catalogApi: CatalogApi;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,6 +2286,75 @@
     yauzl "^3.0.0"
     yn "^4.0.0"
 
+"@backstage/backend-common@^0.23.3":
+  version "0.23.3"
+  resolved "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.23.3.tgz#bba71a3f932a88481ab8e09f4406fc551fb47aec"
+  integrity sha512-/OZRnxlNokdMfoQEfDRrjIuojPi6UL80smHuNpcvP/93fXkrYiMwISulDQPxCfm1Rm9JW8mnRORGFihKIALNpQ==
+  dependencies:
+    "@aws-sdk/abort-controller" "^3.347.0"
+    "@aws-sdk/client-codecommit" "^3.350.0"
+    "@aws-sdk/client-s3" "^3.350.0"
+    "@aws-sdk/credential-providers" "^3.350.0"
+    "@aws-sdk/types" "^3.347.0"
+    "@backstage/backend-dev-utils" "^0.1.4"
+    "@backstage/backend-plugin-api" "^0.7.0"
+    "@backstage/cli-common" "^0.1.14"
+    "@backstage/config" "^1.2.0"
+    "@backstage/config-loader" "^1.8.1"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/integration" "^1.13.0"
+    "@backstage/integration-aws-node" "^0.1.12"
+    "@backstage/plugin-auth-node" "^0.4.17"
+    "@backstage/types" "^1.1.1"
+    "@google-cloud/storage" "^7.0.0"
+    "@keyv/memcache" "^1.3.5"
+    "@keyv/redis" "^2.5.3"
+    "@kubernetes/client-node" "0.20.0"
+    "@manypkg/get-packages" "^1.1.3"
+    "@octokit/rest" "^19.0.3"
+    "@types/cors" "^2.8.6"
+    "@types/dockerode" "^3.3.0"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    "@types/webpack-env" "^1.15.2"
+    archiver "^6.0.0"
+    base64-stream "^1.0.0"
+    compression "^1.7.4"
+    concat-stream "^2.0.0"
+    cors "^2.8.5"
+    dockerode "^4.0.0"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fs-extra "^11.2.0"
+    git-url-parse "^14.0.0"
+    helmet "^6.0.0"
+    isomorphic-git "^1.23.0"
+    jose "^5.0.0"
+    keyv "^4.5.2"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^9.0.0"
+    minimist "^1.2.5"
+    morgan "^1.10.0"
+    mysql2 "^3.0.0"
+    node-fetch "^2.6.7"
+    node-forge "^1.3.1"
+    p-limit "^3.1.0"
+    path-to-regexp "^6.2.1"
+    pg "^8.11.3"
+    raw-body "^2.4.1"
+    selfsigned "^2.0.0"
+    stoppable "^1.1.0"
+    tar "^6.1.12"
+    triple-beam "^1.4.1"
+    uuid "^9.0.0"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+    yauzl "^3.0.0"
+    yn "^4.0.0"
+
 "@backstage/backend-dev-utils@^0.1.4":
   version "0.1.4"
   resolved "https://registry.npmjs.org/@backstage/backend-dev-utils/-/backend-dev-utils-0.1.4.tgz#65d204939c49b5df6a2148e8ad4dc718ccd1df07"
@@ -2301,6 +2370,23 @@
     "@backstage/errors" "^1.2.4"
     "@backstage/plugin-auth-node" "^0.4.16"
     "@backstage/plugin-permission-common" "^0.7.14"
+    "@backstage/types" "^1.1.1"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    express "^4.17.1"
+    knex "^3.0.0"
+    luxon "^3.0.0"
+
+"@backstage/backend-plugin-api@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/@backstage/backend-plugin-api/-/backend-plugin-api-0.7.0.tgz#1a95a8fb5703856e08fef0e94b12f4a50e77ea68"
+  integrity sha512-cq93C7UkS1t/D6VP3XZ8gLD8o3cRmbeSsIUGk+AYiUm0e8aSCWSAlBBiFYrylVOAuQXzEIgE9Gb3MNNFbl+Qug==
+  dependencies:
+    "@backstage/cli-common" "^0.1.14"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/plugin-auth-node" "^0.4.17"
+    "@backstage/plugin-permission-common" "^0.8.0"
     "@backstage/types" "^1.1.1"
     "@types/express" "^4.17.6"
     "@types/luxon" "^3.0.0"
@@ -2337,7 +2423,7 @@
     cross-fetch "^4.0.0"
     uri-template "^2.0.0"
 
-"@backstage/catalog-model@^1.2.1", "@backstage/catalog-model@^1.5.0":
+"@backstage/catalog-model@^1.5.0":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.5.0.tgz#7f5c4a80a3341555db5209fbc6fc2d25f6500707"
   integrity sha512-CfLO5/DMGahneuLU4KTQEs1tgNhBciUtyGUDZB4Ii9i1Uha1poWcqp4HKg61lj1hmXNDUHmlbFqY9W7kmzRC0A==
@@ -2557,6 +2643,21 @@
     lodash "^4.17.21"
     luxon "^3.0.0"
 
+"@backstage/integration@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/@backstage/integration/-/integration-1.13.0.tgz#c7f362c802bda8ecda374e9416cf9cb573d5fce1"
+  integrity sha512-mnzZb0vXQHbFM64HfLrYjnKxhucgkMz+E9ilwXg0XpdK0tlvq2n5RfAFz7BC717BI4l++1epiMFD9hyXAUtxHA==
+  dependencies:
+    "@azure/identity" "^4.0.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@octokit/auth-app" "^4.0.0"
+    "@octokit/rest" "^19.0.3"
+    cross-fetch "^4.0.0"
+    git-url-parse "^14.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+
 "@backstage/plugin-auth-node@^0.4.13", "@backstage/plugin-auth-node@^0.4.16":
   version "0.4.16"
   resolved "https://registry.npmjs.org/@backstage/plugin-auth-node/-/plugin-auth-node-0.4.16.tgz#06409aa6b132c4415eb4390b95edf8f671450175"
@@ -2580,10 +2681,45 @@
     zod "^3.22.4"
     zod-to-json-schema "^3.21.4"
 
+"@backstage/plugin-auth-node@^0.4.17":
+  version "0.4.17"
+  resolved "https://registry.npmjs.org/@backstage/plugin-auth-node/-/plugin-auth-node-0.4.17.tgz#1e890a31ba0795b0c51720282fc72c31c5b7cc2a"
+  integrity sha512-nNZPWPRMCfU0LoxV15bfClPUfZ8XbnKDC4VTMRGyXo37FdRI9uNvrSrZm++e0QKCR/xGfab377SByp/9jITKmQ==
+  dependencies:
+    "@backstage/backend-common" "^0.23.3"
+    "@backstage/backend-plugin-api" "^0.7.0"
+    "@backstage/catalog-client" "^1.6.5"
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/types" "^1.1.1"
+    "@types/express" "*"
+    "@types/passport" "^1.0.3"
+    express "^4.17.1"
+    jose "^5.0.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
+    passport "^0.7.0"
+    winston "^3.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.21.4"
+
 "@backstage/plugin-permission-common@^0.7.14":
   version "0.7.14"
   resolved "https://registry.npmjs.org/@backstage/plugin-permission-common/-/plugin-permission-common-0.7.14.tgz#ecb12877c412ff271124af54fca46ec06d9c812f"
   integrity sha512-fHbxhX9ZoT8bTVuGycfTeU/6TE2yjZ6YNvm/2ko1bcxGnvYe1p5Ug5JW+iWjDZS+F6F152tWzhRcg05wQlPNKQ==
+  dependencies:
+    "@backstage/config" "^1.2.0"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/types" "^1.1.1"
+    cross-fetch "^4.0.0"
+    uuid "^9.0.0"
+    zod "^3.22.4"
+
+"@backstage/plugin-permission-common@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/@backstage/plugin-permission-common/-/plugin-permission-common-0.8.0.tgz#13d29c146c50e9de1da47296c167ace9d1bc86f3"
+  integrity sha512-4c8QfjDKiTJbQfiG3DibUqUsclsi53kRk8GR9CwHl1Is2Xm98AkqXGWyknHGPQOvw4vJR19nqnj7w0XfhLK2Jw==
   dependencies:
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
@@ -2641,12 +2777,13 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cortexapps/backstage-plugin-extensions@0.0.22":
-  version "0.0.22"
-  resolved "https://registry.npmjs.org/@cortexapps/backstage-plugin-extensions/-/backstage-plugin-extensions-0.0.22.tgz#0ca762f8e06180f3d023446e4e7a4b196643dea8"
-  integrity sha512-xocY9WbAJmL4CoAMxAwe4LYJLSv13S7kp66YRY82oMTFuwgSeUNt+kt73224G7Hh6Y+KgDHwYrojGrFkrnwKTQ==
+"@cortexapps/backstage-plugin-extensions@0.0.24":
+  version "0.0.24"
+  resolved "https://registry.npmjs.org/@cortexapps/backstage-plugin-extensions/-/backstage-plugin-extensions-0.0.24.tgz#120a15e68075d24e85d816a170c70de268cd2cc3"
+  integrity sha512-FAym5/ObAPqBeqeaP1HcTgxUgMBxuWoWxRMEm7pWlCgMF6e6NwhNQ6UYqEwuffEykxipm33DhgQtL0qGgr7fgg==
   dependencies:
-    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/backend-plugin-api" "^0.7.0"
+    "@backstage/catalog-model" "^1.5.0"
 
 "@cortexapps/eslint-config-oss@^0.0.3":
   version "0.0.3"


### PR DESCRIPTION
This change introduces a new plugin object created with `createBackendPlugin` and exported from the package root index. Uses `coreServices` defaults for all appropriate service dependencies.

Does not yet support `ExtensionsApi` param of the underlying `createRouter` function.