### PR TITLE
Fix import statement syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ yarn add @cortexapps/backstage-backend-plugin
 2. Update `packages/backend/src/index.ts`:
 
 ```tsx
-import cortexPlugin from '@cortexapps/backstage-backend-plugin';
+import { cortexPlugin } from '@cortexapps/backstage-backend-plugin';
 ...
 const backend = createBackend();
 ...


### PR DESCRIPTION
We don't actually export this object as the default from `index`